### PR TITLE
feature/clock-realtime-offset

### DIFF
--- a/launch/snapdragon_px4_config.yaml
+++ b/launch/snapdragon_px4_config.yaml
@@ -20,7 +20,7 @@ sys:
 # sys_time
 time:
   time_ref_source: "fcu"  # time_reference source
-  timesync_mode: PASSTHROUGH
+  timesync_mode: ONBOARD
   timesync_avg_alpha: 0.6 # timesync averaging factor
 
 # --- mavros plugins (alphabetical order) ---

--- a/src/vislam/SnapdragonVislamManager.hpp
+++ b/src/vislam/SnapdragonVislamManager.hpp
@@ -32,6 +32,7 @@
 #pragma once
 #include <mutex>
 #include <atomic>         // std::atomic
+#include <time.h>         // clock_gettime
 
 #include <ros/ros.h>
 #include <sensor_msgs/Imu.h>


### PR DESCRIPTION
Proper computation and handling of the offset between monotonic and realtime clocks. The messages going out on mavros now all have the proper timestamp correponding to the walltime. 